### PR TITLE
Contrôleur Login

### DIFF
--- a/prive/controleurs/Controleur_Login.php
+++ b/prive/controleurs/Controleur_Login.php
@@ -262,7 +262,7 @@ class Controleur_Login extends Controleur
 			} else
 			{//Affichage de la page login avec l'erreur
 				$this->afficheVue('modeles/en-tete');
-				$this->afficheVue('modeles/menu-admin');
+				$this->afficheVue('modeles/menu-login');
 				$this->afficheFormInscription($messageErreur);
 				$this->afficheVue('modeles/bas-de-page');
 			} 


### PR DESCRIPTION
Lorsque l’inscription d’un nouvel utilisateur renvoyé vers le formulaire avec un message d’erreur c’est la vue modeles/menu-admin qui était utilisé, je viens de remplacer par modeles/menu-login. (je vais déplacer le menu-admin)